### PR TITLE
Add stale activity checker

### DIFF
--- a/.github/workflows/stale_activity.yml
+++ b/.github/workflows/stale_activity.yml
@@ -1,0 +1,32 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 13 * * *'
+    - cron: '39 20 * * *'
+  workflow_dispatch:
+    inputs:
+      days_before_issue_stale:
+        description: 'how many day before consider an issue as stale'
+        default: 30
+        required: false
+        type: number
+      days_before_pr_stale:
+        description: 'how many day before consider a pr as stale'
+        default: 60
+        required: false
+        type: number
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity.'
+          days-before-issue-stale: ${{ github.event.inputs.days_before_issue_stale || 30 }}
+          days-before-pr-stale: ${{ github.event.inputs.days_before_pr_stale || 60 }}
+          days-before-issue-close: 7
+          days-before-pr-close: 14


### PR DESCRIPTION
Add a stale checker run on Github action cronjob to remind and auto close issue/pr that has no activity.